### PR TITLE
Add more tests for column and line macros

### DIFF
--- a/eager2/tests/column.rs
+++ b/eager2/tests/column.rs
@@ -1,0 +1,39 @@
+mod eager_column {
+    use eager2::eager;
+
+    #[test]
+    fn test_column() {
+        // TODO: `eager2::column!()` should return the **start**
+        //       of the macro call. But when wrapped in `eager! { }`,
+        //       it currently returns ...
+        //       eager2::column!()
+        //                      ^
+        //                     this
+        //       ... while it should return ...
+        //       eager2::column!()
+        //       ^
+        //      this
+        #[rustfmt::skip]
+        const A: u32 =                 column!();
+        const B: u32 = eager! { column!() };
+        assert_eq!(A, B); // ???
+
+        #[rustfmt::skip]
+        assert_eq!(eager! {
+            eager2::column!()
+        },                 column!());
+        #[rustfmt::skip]
+        assert_eq!(eager! {
+            eager2::column!()
+        },                 std::column!());
+
+        #[rustfmt::skip]
+        assert_eq!(eager! {
+            column!()
+        },         column!());
+        #[rustfmt::skip]
+        assert_eq!(eager! {
+            column!()
+        },         std::column!());
+    }
+}

--- a/eager2/tests/line.rs
+++ b/eager2/tests/line.rs
@@ -1,0 +1,9 @@
+mod eager_line {
+    use eager2::eager;
+
+    #[test]
+    fn test_line() {
+        assert_eq!(eager! { eager2::line!() }, line!());
+        assert_eq!(eager! { eager2::line!() }, line!());
+    }
+}


### PR DESCRIPTION
The `column!` test-case actually shows a bug (I suppose). I wrote it so `cargo test` still passes, but the bug is still on `master` and needs some fixes, if doable