### PR TITLE
#1 - feat: add support for (unstable) declarative `macro`s v2 and `proc-macro`s

### DIFF
--- a/eager2-core/Cargo.toml
+++ b/eager2-core/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro2 = { version = "1", optional = true }
 quote = { version = "1", optional = true }
 
 [features]
-"testing" = ["proc-macro2", "quote"]
+testing = ["dep:proc-macro2", "dep:quote"]

--- a/eager2-core/build.rs
+++ b/eager2-core/build.rs
@@ -1,0 +1,201 @@
+use std::{
+    borrow::Cow,
+    collections::VecDeque,
+    env,
+    error::Error as StdError,
+    fmt::{self, Debug, Formatter, Write},
+    ops::{Deref, DerefMut},
+    process::{Command, ExitCode, Termination},
+    rc::Rc,
+};
+
+#[repr(transparent)]
+struct Error(Rc<dyn StdError>);
+
+impl<T: StdError + 'static> From<T> for Error {
+    fn from(value: T) -> Self {
+        Self(Rc::new(value))
+    }
+}
+
+impl Deref for Error {
+    type Target = Rc<dyn StdError>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Error {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_char('\n')?;
+        let mut errors = VecDeque::from([&*self.0]);
+        while let Some(src) = self.0.source() {
+            errors.push_front(src);
+        }
+        for (i, err) in errors.iter().enumerate() {
+            writeln!(f, "\t#{i}: {err}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ErrString(Cow<'static, str>);
+
+impl StdError for ErrString {}
+
+impl fmt::Display for ErrString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0.to_string().as_str())
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum RustcChannel {
+    Stable,
+    Beta,
+    Nightly,
+}
+
+impl fmt::Display for RustcChannel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+            Self::Nightly => "nightly",
+        })
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct RustcVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    channel: RustcChannel,
+}
+
+impl TryFrom<(&str, &str, &str, &str)> for RustcVersion {
+    type Error = Error;
+    fn try_from(value: (&str, &str, &str, &str)) -> Result<Self, Self::Error> {
+        Ok(Self {
+            major: value.0.parse()?,
+            minor: value.1.parse()?,
+            patch: value.2.parse()?,
+            channel: match value.3.to_lowercase().as_str() {
+                "stable" => Ok(RustcChannel::Stable),
+                "beta" => Ok(RustcChannel::Beta),
+                "nightly" => Ok(RustcChannel::Nightly),
+                s => Err(ErrString(format!("unknown rust channel: {s}").into())),
+            }?,
+        })
+    }
+}
+
+impl fmt::Display for RustcVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "rustc {}.{}.{}-{}",
+            self.major, self.minor, self.patch, self.channel
+        )
+    }
+}
+
+fn main() -> Result<impl Termination, Error> {
+    let rustc = env::var("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output()?;
+    if !output.status.success() {
+        return Ok(ExitCode::from(
+            output
+                .status
+                .code()
+                .expect("could not retrieve status code") as u8,
+        ));
+    }
+    let stdout = output
+        .stdout
+        .trim_ascii_start()
+        .strip_prefix(b"rustc ")
+        .expect("rustc version output does not start with \"rustc\"");
+
+    let next_sep = stdout
+        .iter()
+        .position(|byte| *byte == b'.')
+        .expect("could not retrieve rustc major version");
+    let maj = &stdout[0..next_sep];
+    let stdout = unsafe {
+        stdout
+            .strip_prefix(maj)
+            .unwrap_unchecked()
+            .strip_prefix(b".")
+            .unwrap_unchecked()
+    };
+
+    let next_sep = stdout
+        .iter()
+        .position(|byte| *byte == b'.')
+        .expect("could not retrieve rustc minor version");
+    let min = &stdout[0..next_sep];
+    let stdout = unsafe {
+        stdout
+            .strip_prefix(min)
+            .unwrap_unchecked()
+            .strip_prefix(b".")
+            .unwrap_unchecked()
+    };
+
+    let mut have_channel_info = false;
+    let next_sep = stdout
+        .iter()
+        .position(|byte| {
+            if *byte == b'-' {
+                have_channel_info = true;
+            }
+            byte.is_ascii_whitespace() || *byte == b'-'
+        })
+        .expect("could not retrieve rustc major version");
+    let patch = &stdout[0..next_sep];
+    let stdout = unsafe {
+        stdout
+            .strip_prefix(patch)
+            .unwrap_unchecked()
+            .strip_prefix(if have_channel_info {
+                b"-".as_slice()
+            } else {
+                b""
+            })
+            .unwrap_unchecked()
+            .trim_ascii_start()
+    };
+
+    let channel = if have_channel_info {
+        stdout
+            .iter()
+            .take_while(|byte| !byte.is_ascii_whitespace())
+            .copied()
+            .collect()
+    } else {
+        b"stable".to_vec()
+    };
+
+    let rustversion: RustcVersion = (
+        str::from_utf8(maj)?,
+        str::from_utf8(min)?,
+        str::from_utf8(patch)?,
+        str::from_utf8(&channel)?,
+    )
+        .try_into()?;
+
+    println!("cargo::rustc-check-cfg=cfg(rustchan, values(\"stable\", \"beta\", \"nightly\"))");
+    println!("cargo::rustc-cfg=rustchan=\"{}\"", rustversion.channel);
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/eager2-core/src/consts.rs
+++ b/eager2-core/src/consts.rs
@@ -8,13 +8,34 @@ pub const LAZY_SIGIL: &str = "𓆉";
 pub const EAGER_SIGIL: &str = "𓂺";
 
 #[must_use]
+#[inline(always)]
 pub fn get_eager_2_ident() -> Ident {
     Ident::new(EAGER2_IDENT, Span::call_site())
 }
 
 #[must_use]
+#[inline(always)]
+pub(crate) fn get_eager_2_pm_ident(suffix: Option<&str>) -> Ident {
+    Ident::new(
+        format!("{EAGER2_IDENT}{s}", s = suffix.unwrap_or_default()).as_str(),
+        Span::call_site(),
+    )
+}
+
+#[must_use]
+#[inline(always)]
 pub fn eager_call_sigil() -> Literal {
     Literal::from_str(EAGER_CALL_SIGIL).unwrap()
+}
+
+#[must_use]
+#[inline(always)]
+pub(crate) fn eager_call_sigil_proc_macro() -> TokenStream {
+    use crate::interpolate;
+
+    interpolate! {
+        ::proc_macro::Literal::from_str(#EAGER_CALL_SIGIL).unwrap()
+    }
 }
 
 #[must_use]

--- a/eager2-core/src/lib.rs
+++ b/eager2-core/src/lib.rs
@@ -1,5 +1,7 @@
-//! This library is not meant for public consumption
+#![cfg_attr(rustchan = "nightly", feature(proc_macro_span))]
+#![recursion_limit = "1024"]
 
+//! This library is not meant for public consumption
 #![doc(hidden)]
 
 use std::borrow::Cow;
@@ -50,6 +52,28 @@ pub mod pm {
     impl ToTokens for TokenTree {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.extend([self.clone()]);
+        }
+    }
+    impl ToTokens for TokenStream {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            tokens.extend([self.clone()]);
+        }
+    }
+    impl ToTokens for &str {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            Literal::string(self).to_tokens(tokens);
+        }
+    }
+    impl<const N: usize, T: ToTokens> ToTokens for [T; N] {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            for item in self {
+                item.to_tokens(tokens);
+            }
+        }
+    }
+    impl<T: ToTokens> ToTokens for &T {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            (*self).to_tokens(tokens);
         }
     }
 }

--- a/eager2-core/src/utils.rs
+++ b/eager2-core/src/utils.rs
@@ -1,4 +1,7 @@
-use crate::pm::{Delimiter, Group, Literal, ToTokens, TokenStream};
+use crate::{
+    parse::IdentOrString,
+    pm::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, ToTokens, TokenStream},
+};
 pub trait NextOr: Iterator {
     fn next_or<E>(&mut self, e: E) -> Result<Self::Item, E>;
 }
@@ -30,6 +33,22 @@ where
 }
 
 #[must_use]
+pub(crate) fn lifetime(name: IdentOrString) -> TokenStream {
+    let mut stream = TokenStream::new();
+    Punct::new('\'', Spacing::Joint).to_tokens(&mut stream);
+    Ident::new(
+        match name {
+            IdentOrString::Ident(i) => i.to_string(),
+            IdentOrString::String(s) => s,
+        }
+        .as_str(),
+        Span::call_site(),
+    )
+    .to_tokens(&mut stream);
+    stream
+}
+
+#[must_use]
 pub fn eager_data(
     eager_call_sigil: &Literal,
     state: TokenStream,
@@ -40,4 +59,220 @@ pub fn eager_data(
     Group::new(Delimiter::Bracket, state).to_tokens(&mut tokens);
     tokens.extend(tail);
     tokens
+}
+
+/// Roughly the same as `quote::quote!`, but faster, without repetitions,
+/// and working directly with proc_macro. There might exist some valid Rust
+/// code which could not be recognised by this macro, but it's enough for
+/// our use case
+#[macro_export]
+macro_rules! interpolate {
+    {} => {
+        ::proc_macro::TokenStream::new()
+    };
+    {$($tokens:tt)+} => {{
+        let mut interpolated = $crate::interpolate! {};
+        interpolated.extend(
+            $crate::interpolate_inner! {
+                @already_interpolated[::proc_macro::TokenStream::new()]
+                $($tokens)+
+            }
+        );
+        interpolated
+    }};
+}
+
+#[macro_export]
+macro_rules! interpolate_inner {
+    {@already_interpolated[$($interpolated:tt)*]} => {[$($interpolated)*]};
+
+    // interpolated
+    {@already_interpolated[$($interpolated:tt)*] #$ident:ident $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::to_token_stream(
+                    &$ident
+                )
+            ]
+            $($rest)*
+        }
+    };
+
+    // ident
+    {@already_interpolated[$($interpolated:tt)*] $ident:ident $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    ::proc_macro::Ident::new(
+                        stringify!($ident),
+                        ::proc_macro::Span::call_site()
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+    {@already_interpolated[$($interpolated:tt)*] _ $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    ::proc_macro::Ident::new(
+                        "_",
+                        ::proc_macro::Span::call_site()
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+
+    // literal
+    {@already_interpolated[$($interpolated:tt)*] $lit:literal $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                {
+                    use ::core::str::FromStr;
+
+                    $crate::pm::ToTokens::into_token_stream(
+                        ::proc_macro::Literal::from_str(
+                            stringify!($lit)
+                        ).expect(
+                            concat!(
+                                "`interpolate!` could not create a literal with ",
+                                stringify!($lit)
+                            )
+                        )
+                    )
+                }
+            ]
+
+            $($rest)*
+        }
+    };
+
+    // group
+    {@already_interpolated[$($interpolated:tt)*] { $($tokens:tt)* } $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    ::proc_macro::Group::new(
+                        ::proc_macro::Delimiter::Brace,
+                        $crate::interpolate! { $($tokens)* }
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+    {@already_interpolated[$($interpolated:tt)*] [ $($tokens:tt)* ] $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    ::proc_macro::Group::new(
+                        ::proc_macro::Delimiter::Bracket,
+                        $crate::interpolate! { $($tokens)* }
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+    {@already_interpolated[$($interpolated:tt)*] ( $($tokens:tt)* ) $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    ::proc_macro::Group::new(
+                        ::proc_macro::Delimiter::Parenthesis,
+                        $crate::interpolate! { $($tokens)* }
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+
+    // special tokens
+    {@already_interpolated[$($interpolated:tt)*] $lifetime:lifetime $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    $crate::utils::quote_lifetime(
+                        stringify!($lifetime)
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+
+    // punct (or related)
+    // this matches a [`Token`](https://doc.rust-lang.org/nightly/reference/tokens.html#grammar-Token),
+    // which, at this point must be a [`PUNCTUATION`](https://doc.rust-lang.org/nightly/reference/tokens.html#grammar-PUNCTUATION)
+    {@already_interpolated[$($interpolated:tt)*] $punct:tt $($rest:tt)*} => {
+        $crate::interpolate_inner! {
+            @already_interpolated[
+                $($interpolated)*,
+                $crate::pm::ToTokens::into_token_stream(
+                    $crate::utils::quote_punct(
+                        stringify!($punct)
+                    )
+                )
+            ]
+            $($rest)*
+        }
+    };
+}
+
+#[allow(dead_code)]
+pub(crate) fn quote_lifetime(lifetime: &str) -> TokenStream {
+    let trimmed = lifetime.trim();
+    debug_assert_eq!(trimmed.chars().next(), Some('\''));
+
+    let mut stream = TokenStream::new();
+
+    // SAFETY: « ' » needs one byte to be encoded as UTF-8,
+    // so removing it still yields valid UTF-8
+    let name = unsafe { str::from_utf8_unchecked(&lifetime.as_bytes()[1..]) };
+
+    Punct::new('\'', Spacing::Joint).to_tokens(&mut stream);
+    Ident::new(name, Span::call_site()).to_tokens(&mut stream);
+
+    stream
+}
+
+#[allow(dead_code)]
+pub(crate) fn quote_punct(punct: &str) -> TokenStream {
+    let trimmed = punct.trim();
+    debug_assert!(trimmed.chars().count() <= 3);
+
+    let mut stream = TokenStream::new();
+    let mut chars = trimmed.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if chars.peek().is_some() {
+            Punct::new(ch, Spacing::Joint).to_tokens(&mut stream);
+        } else {
+            Punct::new(ch, Spacing::Alone).to_tokens(&mut stream);
+        }
+    }
+
+    stream
+}
+
+#[cfg(rustchan = "nightly")]
+pub(crate) fn join_spans(s1: Span, s2: Span) -> Span {
+    s1.join(s2).unwrap_or(s1)
+}
+
+#[cfg(not(rustchan = "nightly"))]
+pub(crate) fn join_spans(s1: Span, _: Span) -> Span {
+    s1
 }

--- a/eager2/Cargo.toml
+++ b/eager2/Cargo.toml
@@ -21,4 +21,4 @@ litrs = { version = "0.4", default-features = false }
 eager2-core = { workspace = true }
 
 [features]
-trace_macros = []
+trace-macros = []

--- a/eager2/build.rs
+++ b/eager2/build.rs
@@ -1,0 +1,201 @@
+use std::{
+    borrow::Cow,
+    collections::VecDeque,
+    env,
+    error::Error as StdError,
+    fmt::{self, Debug, Formatter, Write},
+    ops::{Deref, DerefMut},
+    process::{Command, ExitCode, Termination},
+    rc::Rc,
+};
+
+#[repr(transparent)]
+struct Error(Rc<dyn StdError>);
+
+impl<T: StdError + 'static> From<T> for Error {
+    fn from(value: T) -> Self {
+        Self(Rc::new(value))
+    }
+}
+
+impl Deref for Error {
+    type Target = Rc<dyn StdError>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Error {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_char('\n')?;
+        let mut errors = VecDeque::from([&*self.0]);
+        while let Some(src) = self.0.source() {
+            errors.push_front(src);
+        }
+        for (i, err) in errors.iter().enumerate() {
+            writeln!(f, "\t#{i}: {err}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ErrString(Cow<'static, str>);
+
+impl StdError for ErrString {}
+
+impl fmt::Display for ErrString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0.to_string().as_str())
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum RustcChannel {
+    Stable,
+    Beta,
+    Nightly,
+}
+
+impl fmt::Display for RustcChannel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+            Self::Nightly => "nightly",
+        })
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct RustcVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    channel: RustcChannel,
+}
+
+impl TryFrom<(&str, &str, &str, &str)> for RustcVersion {
+    type Error = Error;
+    fn try_from(value: (&str, &str, &str, &str)) -> Result<Self, Self::Error> {
+        Ok(Self {
+            major: value.0.parse()?,
+            minor: value.1.parse()?,
+            patch: value.2.parse()?,
+            channel: match value.3.to_lowercase().as_str() {
+                "stable" => Ok(RustcChannel::Stable),
+                "beta" => Ok(RustcChannel::Beta),
+                "nightly" => Ok(RustcChannel::Nightly),
+                s => Err(ErrString(format!("unknown rust channel: {s}").into())),
+            }?,
+        })
+    }
+}
+
+impl fmt::Display for RustcVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "rustc {}.{}.{}-{}",
+            self.major, self.minor, self.patch, self.channel
+        )
+    }
+}
+
+fn main() -> Result<impl Termination, Error> {
+    let rustc = env::var("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output()?;
+    if !output.status.success() {
+        return Ok(ExitCode::from(
+            output
+                .status
+                .code()
+                .expect("could not retrieve status code") as u8,
+        ));
+    }
+    let stdout = output
+        .stdout
+        .trim_ascii_start()
+        .strip_prefix(b"rustc ")
+        .expect("rustc version output does not start with \"rustc\"");
+
+    let next_sep = stdout
+        .iter()
+        .position(|byte| *byte == b'.')
+        .expect("could not retrieve rustc major version");
+    let maj = &stdout[0..next_sep];
+    let stdout = unsafe {
+        stdout
+            .strip_prefix(maj)
+            .unwrap_unchecked()
+            .strip_prefix(b".")
+            .unwrap_unchecked()
+    };
+
+    let next_sep = stdout
+        .iter()
+        .position(|byte| *byte == b'.')
+        .expect("could not retrieve rustc minor version");
+    let min = &stdout[0..next_sep];
+    let stdout = unsafe {
+        stdout
+            .strip_prefix(min)
+            .unwrap_unchecked()
+            .strip_prefix(b".")
+            .unwrap_unchecked()
+    };
+
+    let mut have_channel_info = false;
+    let next_sep = stdout
+        .iter()
+        .position(|byte| {
+            if *byte == b'-' {
+                have_channel_info = true;
+            }
+            byte.is_ascii_whitespace() || *byte == b'-'
+        })
+        .expect("could not retrieve rustc major version");
+    let patch = &stdout[0..next_sep];
+    let stdout = unsafe {
+        stdout
+            .strip_prefix(patch)
+            .unwrap_unchecked()
+            .strip_prefix(if have_channel_info {
+                b"-".as_slice()
+            } else {
+                b""
+            })
+            .unwrap_unchecked()
+            .trim_ascii_start()
+    };
+
+    let channel = if have_channel_info {
+        stdout
+            .iter()
+            .take_while(|byte| !byte.is_ascii_whitespace())
+            .copied()
+            .collect()
+    } else {
+        b"stable".to_vec()
+    };
+
+    let rustversion: RustcVersion = (
+        str::from_utf8(maj)?,
+        str::from_utf8(min)?,
+        str::from_utf8(patch)?,
+        str::from_utf8(&channel)?,
+    )
+        .try_into()?;
+
+    println!("cargo::rustc-check-cfg=cfg(rustchan, values(\"stable\", \"beta\", \"nightly\"))");
+    println!("cargo::rustc-cfg=rustchan=\"{}\"", rustversion.channel);
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/eager2/src/impls.rs
+++ b/eager2/src/impls.rs
@@ -6,7 +6,7 @@ pub fn eval(stream: TokenStream, eager: bool) -> TokenStream {
     init();
     let _name = if eager { "eager" } else { "lazy" };
 
-    #[cfg(feature = "trace_macros")]
+    #[cfg(feature = "trace-macros")]
     println!("{} input: {}", _name, stream);
 
     let output = match eager2_core::funcs::mode(stream, eager) {
@@ -14,7 +14,7 @@ pub fn eval(stream: TokenStream, eager: bool) -> TokenStream {
         Err(err) => return err.into_token_stream(),
     };
 
-    #[cfg(feature = "trace_macros")]
+    #[cfg(feature = "trace-macros")]
     println!("{} output: {}", _name, output);
 
     output
@@ -23,7 +23,7 @@ pub fn eval(stream: TokenStream, eager: bool) -> TokenStream {
 #[allow(clippy::needless_pass_by_value)]
 pub fn eager_wrap(stream: TokenStream, name: &str) -> TokenStream {
     init();
-    #[cfg(feature = "trace_macros")]
+    #[cfg(feature = "trace-macros")]
     println!("{} input: {}", name, stream);
 
     let output = match eager2_core::funcs::eager_wrap(stream, name) {
@@ -31,7 +31,7 @@ pub fn eager_wrap(stream: TokenStream, name: &str) -> TokenStream {
         Err(err) => return err.into_token_stream(),
     };
 
-    #[cfg(feature = "trace_macros")]
+    #[cfg(feature = "trace-macros")]
     println!("{} output: {}", name, output);
 
     output


### PR DESCRIPTION
This pull request is the first to examine and to merge. It contains additions and modifications needed to support the actual parsing and processing of macros v2 and proc-macros. Please consider the fact that it may not pass ci runs since a lot of code will remain unused (i.e. `dead_code`) while the other PRs are not also merged