### PR TITLE
fix(#19): Fix column and line macros. Also doc fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ This crate contains five core macros used to simulate eager macro expansion:
 * [`eager_macro_rules!`]: The legacy way to declares one or more eager-enabled macro.
 
 In addition to these primary macros, eager versions of standard library are provided (macros
-only useful at runtime like `vec` are still lazy and `cfg!`, `column!`, `file!`, `line!`, and
-`module_path!` are reserved for future implementation). If you wish to use the lazy versions of
-the standard library, you can either insert a `lazy!{}` or `suspend_eager!{}` block around
-them, or use the full path (e.g. `std::concat`). Please note the latter of which will only work
-for macros from `std`, `core`, and `alloc`. All other lazy macro calls must be wrapped in `lazy`
-or `suspend_eager`.
+only useful at runtime like `vec` are still lazy and `cfg!` and `module_path!` are reserved for
+future implementation). If you wish to use the lazy versions of the standard library, you can
+either insert a `lazy!{}` or `suspend_eager!{}` block around them, or use the full path (e.g.
+`std::concat`). Please note the latter of which will only work for macros from `std`, `core`,
+and `alloc`. All other lazy macro calls must be wrapped in `lazy` or `suspend_eager`.
 
 Some additional helpers are also provided:
 

--- a/eager2-core/Cargo.toml
+++ b/eager2-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eager2-core"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Daniel Bloom"]
 edition = "2021"
 categories = ["development-tools"]

--- a/eager2-core/README.md
+++ b/eager2-core/README.md
@@ -1,0 +1,6 @@
+# eager2-core
+
+This is a helper crate for [`eager2`](../README.md). It exists to reduce compile times by:
+* Having 0 dependencies (except for those used for testing)
+* Not having a build script
+* Containing as much of the code as possible (i.e. reducing the `eager2` code which needs to be compiled)

--- a/eager2-core/src/exec.rs
+++ b/eager2-core/src/exec.rs
@@ -84,16 +84,18 @@ impl TryFrom<&str> for ExecutableMacroType {
 impl ExecutableMacroType {
     pub fn execute(
         self,
+        path_span: Span,
         span: Span,
         stream: impl IntoIterator<Item = TokenTree>,
         processed: &mut EfficientGroupV,
         unprocessed: &mut Vec<token_stream::IntoIter>,
     ) -> Result<(), Error> {
-        self.execute_impl(span, &mut stream.into_iter(), processed, unprocessed)
+        self.execute_impl(path_span, span, &mut stream.into_iter(), processed, unprocessed)
     }
 
     fn execute_impl(
         self,
+        path_span: Span,
         span: Span,
         args: &mut dyn Iterator<Item = TokenTree>,
         processed: &mut EfficientGroupV,
@@ -106,7 +108,7 @@ impl ExecutableMacroType {
                 let fexecs = FNS.get().unwrap();
                 (fexecs.execute_concat)(span, args, processed)
             }
-            Self::Column => execute_column(span, args, processed),
+            Self::Column => execute_column(path_span, args, processed),
             Self::Env => execute_env(span, args, processed),
             Self::File => execute_file(span, args, processed),
             Self::Stringify => {
@@ -116,7 +118,7 @@ impl ExecutableMacroType {
             Self::Include => execute_include(span, args, unprocessed),
             Self::IncludeBytes => execute_include_bytes(span, args, processed),
             Self::IncludeStr => execute_include_str(span, args, processed),
-            Self::Line => execute_line(span, args, processed),
+            Self::Line => execute_line(path_span, args, processed),
             Self::ModulePath => execute_module_path(span, args, processed),
             Self::OptionEnv => execute_option_env(span, args, processed),
 

--- a/eager2-core/src/state.rs
+++ b/eager2-core/src/state.rs
@@ -238,9 +238,10 @@ impl ModeSwitchTrailingMacro {
     }
 }
 impl ExecutableTrailingMacro {
-    fn truncate(self, tokens: &mut Vec<TokenTree>) -> ExecutableMacroType {
+    fn truncate(self, tokens: &mut Vec<TokenTree>) -> (Span, ExecutableMacroType) {
+        let path_span = tokens[self.offset].span();
         tokens.truncate(self.offset);
-        self.exec
+        (path_span, self.exec)
     }
 }
 impl UnknownTrailingMacro {
@@ -557,7 +558,7 @@ impl State {
             }
             // Execute known macros
             (Some(Exec(tm)), Mode::Eager) => {
-                let macro_type = tm.truncate(self.processed.as_mut_vec());
+                let (path_span, macro_type) = tm.truncate(self.processed.as_mut_vec());
                 let stream = stack
                     .free
                     .into_iter()
@@ -565,6 +566,7 @@ impl State {
                     .chain(stack.processed);
 
                 macro_type.execute(
+                    path_span,
                     stack.span,
                     stream,
                     &mut self.processed,

--- a/eager2/Cargo.toml
+++ b/eager2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eager2"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Daniel Bloom"]
 edition = "2021"
 categories = ["development-tools"]

--- a/eager2/src/lib.rs
+++ b/eager2/src/lib.rs
@@ -8,12 +8,11 @@
 //! * [`eager_macro_rules!`]: The legacy way to declares one or more eager-enabled macro.
 //!
 //! In addition to these primary macros, eager versions of standard library are provided (macros
-//! only useful at runtime like `vec` are still lazy and `cfg!`, `column!`, `file!`, `line!`, and
-//! `module_path!` are reserved for future implementation). If you wish to use the lazy versions of
-//! the standard library, you can either insert a `lazy!{}` or `suspend_eager!{}` block around
-//! them, or use the full path (e.g. `std::concat`). Please note the latter of which will only work
-//! for macros from `std`, `core`, and `alloc`. All other lazy macro calls must be wrapped in `lazy`
-//! or `suspend_eager`.
+//! only useful at runtime like `vec` are still lazy and `cfg!` and `module_path!` are reserved for
+//! future implementation). If you wish to use the lazy versions of the standard library, you can
+//! either insert a `lazy!{}` or `suspend_eager!{}` block around them, or use the full path (e.g.
+//! `std::concat`). Please note the latter of which will only work for macros from `std`, `core`,
+//! and `alloc`. All other lazy macro calls must be wrapped in `lazy` or `suspend_eager`.
 //!
 //! Some additional helpers are also provided:
 //!
@@ -592,8 +591,6 @@ pub fn cfg(stream: TokenStream) -> TokenStream {
     impls::eager_wrap(stream.into(), "cfg").into()
 }
 
-/// 🚧 Not yet implemented!
-///
 /// [[eager!](macro.eager.html)] Expands to the column number at which it was invoked.
 ///
 /// With [`line!`] and [`file!`], these macros provide debugging information for
@@ -662,8 +659,6 @@ pub fn option_env(stream: TokenStream) -> TokenStream {
     impls::eager_wrap(stream.into(), "option_env").into()
 }
 
-/// 🚧 Not yet implemented!
-///
 /// [[eager!](macro.eager.html)] Expands to the file name in which it was invoked.
 ///
 /// With [`line!`] and [`column!`], these macros provide debugging information for
@@ -727,8 +722,6 @@ pub fn include_str(stream: TokenStream) -> TokenStream {
     impls::eager_wrap(stream.into(), "include_str").into()
 }
 
-/// 🚧 Not yet implemented!
-///
 /// [[eager!](macro.eager.html)] Expands to the line number on which it was invoked.
 ///
 /// With [`column!`] and [`file!`], these macros provide debugging information for

--- a/eager2/tests/column.rs
+++ b/eager2/tests/column.rs
@@ -1,0 +1,62 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+use eager2::eager;
+
+#[test]
+fn test_1() {
+    const A: u32 = column!();
+    const B: u32 = eager2::column!();
+    assert_eq!(A, B);
+}
+
+#[test]
+fn test_2() {
+    const A: u32 = std::
+column!();
+    const B: u32 = eager2::
+column!();
+    assert_eq!(A, B);
+}
+
+#[test]
+fn test_3() {
+    const A: u32 =          column!();
+    const B: u32 = eager! { column!() };
+    assert_eq!(A, B);
+}
+
+#[test]
+fn test_4() {
+    const A: u32 = eager! {
+                   eager2::column!()
+    };
+    const B: u32 = column!();
+    assert_eq!(A, B);
+}
+
+#[test]
+fn test_5() {
+    const A: u32 = eager! {
+                   eager2::column!()
+    };
+    const B: u32 = std::column!();
+    assert_eq!(A, B);
+}
+
+#[test]
+fn test_6() {
+    const A: u32 = eager! {
+                   column!()
+    };
+    const B: u32 = std::column!();
+    assert_eq!(A, B);
+}
+
+#[test]
+fn test_7() {
+    const A: u32 = eager! {
+                   eager2::
+column!()
+    };
+    const B: u32 = std::column!();
+    assert_eq!(A, B);
+}

--- a/eager2/tests/env.rs
+++ b/eager2/tests/env.rs
@@ -7,22 +7,6 @@ fn test_env() {
 }
 
 #[test]
-fn test_line() {
-    const FOO: u32 = eager2::line!();
-    const BAR: u32 = line!();
-
-    assert_eq!(FOO + 1, BAR);
-}
-
-#[test]
-fn test_column() {
-    const FOO: u32 = eager2::column!();
-    const BAR: u32 = column!();
-
-    assert_eq!(FOO, BAR);
-}
-
-#[test]
 fn test_file() {
     const FOO: &str = eager2::file!();
     const BAR: &str = file!();

--- a/eager2/tests/line.rs
+++ b/eager2/tests/line.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+use eager2::eager;
+
+#[test]
+fn test_1() {
+    const A: u32 = line!();
+    const B: u32 = eager2::line!();
+    assert_eq!(A + 1, B);
+}
+
+
+#[test]
+fn test_2() {
+    const A: u32 = std::
+line!();
+    const B: u32 = eager2::
+line!();
+    assert_eq!(A + 2, B);
+}
+
+#[test]
+fn test_3() {
+    const A: u32 =          line!();
+    const B: u32 = eager! {
+        line!()
+    };
+    assert_eq!(A + 2, B);
+}
+
+#[test]
+fn test_4() {
+    const A: u32 = eager! {
+                   eager2::
+line!()
+    };
+    const B: u32 = std::line!();
+    assert_eq!(A+3, B);
+}


### PR DESCRIPTION
This should fix `line` and `column` macros.